### PR TITLE
Please include unistd.h for portability

### DIFF
--- a/include/watcher/adapter/linux/watch.hpp
+++ b/include/watcher/adapter/linux/watch.hpp
@@ -11,6 +11,7 @@
 
 #include <sys/epoll.h>
 #include <sys/inotify.h>
+#include <unistd.h>
 #include <chrono>
 #include <filesystem>
 #include <iostream>


### PR DESCRIPTION
I am creating a watcher conan package.
https://github.com/conan-io/conan-center-index/pull/13638

I have encountered this compile error with some compilers.
https://c3i.jfrog.io/c3i/misc/logs/pr/13638/8-linux-clang/watcher/0.3.1//5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9-test.txt

It seems to be caused by the missing unistd.h.
Could you please merge them if possible?
