### PR TITLE
include atomic in Linux and Android

### DIFF
--- a/include/wtr/watcher.hpp
+++ b/include/wtr/watcher.hpp
@@ -1247,6 +1247,7 @@ inline auto watch(
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 7, 0)) || defined(__ANDROID_API__)
 
+#include <atomic>
 #include <cassert>
 #include <cstring>
 #include <filesystem>


### PR DESCRIPTION
In code for Linux, std::atomic_bool is required.
https://github.com/e-dant/watcher/blob/release/0.9.0/include/wtr/watcher.hpp#L1550

But `<atomic>` is not included.
It causes a compilation error.

This PR try to fix it.