### PR TITLE
Fixes generated c-library version

### DIFF
--- a/watcher-c/meson.build
+++ b/watcher-c/meson.build
@@ -12,9 +12,7 @@ watcher_hpp = custom_target(
 )
 watcher_hpp_dep = declare_dependency(sources : watcher_hpp)
 
-# I know it's not the convential way to version a library...
-# But I'm not sure how to do it the "right" way in Meson.
-libwatcher_c_name = 'watcher-c-' + meson.project_version()
+libwatcher_c_name = 'watcher-c'
 
 if target_machine.system() == 'darwin'
   libwatcher_c_deps = [dependency('CoreServices'), dependency('CoreFoundation'), watcher_hpp_dep]
@@ -31,6 +29,7 @@ libwatcher_c = library(
   build_rpath : '/usr/local/lib',
   install_rpath : '/usr/local/lib',
   install : true,
+  version : meson.project_version(),
 )
 
 test_libwatcher_c = executable(


### PR DESCRIPTION
Currently when building the c-lib with meson I'm getting a `libwatcher-c-0.11.0.so`, which requires me to import the library with the version attached (`LDFLAGS: -lwatcher-c-0.11.0`).

It is more common attach to the version at the end of the .so file, like this: `libwatcher-c.so.0.11.0`.

This commit fixes that behavior

Files generated with meson compile before this commit:
`libwatcher-c-0.11.0.so  libwatcher-c-0.11.0.so.p`

Files generated after:
`libwatcher-c.so  libwatcher-c.so.0  libwatcher-c.so.0.11.0  libwatcher-c.so.0.11.0.p`