### PR TITLE
Linux: Fix epoll_wait failing with EINTR.

### DIFF
--- a/include/wtr/watcher.hpp
+++ b/include/wtr/watcher.hpp
@@ -1671,8 +1671,9 @@ inline auto watch =
     while (sr.ok < result::complete) {
       int ep_c =
         epoll_wait(sr.ep.fd, sr.ep.interests, sr.ep.q_ulim, sr.ep.wake_ms);
-      if (ep_c < 0)
-        sr.ok = result::e_sys_api_epoll;
+      if (ep_c < 0) {
+        if (errno != EINTR) sr.ok = result::e_sys_api_epoll;
+      }
       else
         for (int n = 0; n < ep_c; ++n)
           if (is_ev_of(n, sr.il.fd))


### PR DESCRIPTION
Watcher would usually immediately `e/sys/api/epoll` and `e/self/die` on my system.

I guess `epoll_wait` can spontaneously fail with `EINTR`.
See:
https://stackoverflow.com/questions/6870158/epoll-wait-fails-due-to-eintr-how-to-remedy-this

This fixes the problem on my system.