### PR TITLE
tests(go): fix tests on Linux

### DIFF
--- a/.github/workflows/watcher-go.yml
+++ b/.github/workflows/watcher-go.yml
@@ -35,7 +35,7 @@ jobs:
           sudo cmake --install build
       - if: matrix.os == 'ubuntu-latest'
         run: sudo ldconfig
-      - run: go test -race
+      - run: go test -race -v -timeout 30s
         working-directory: watcher-go
       - uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/watcher-go.yml
+++ b/.github/workflows/watcher-go.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 
+env:
+  DYLD_LIBRARY_PATH: /usr/local/lib
+  CGO_CFLAGS: -I/usr/local/include
+  CGO_LDFLAGS: -L/usr/local/lib
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -28,6 +33,8 @@ jobs:
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
           cmake --build build
           sudo cmake --install build
+      - if: matrix.os == 'ubuntu-latest'
+        run: sudo ldconfig
       - run: go test -race
         working-directory: watcher-go
       - uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/watcher-go.yml
+++ b/.github/workflows/watcher-go.yml
@@ -3,6 +3,8 @@ name: Test (Go)
 on:
   push:
     branches: [ release, next ]
+  pull_request:
+    branches: [ release, next ]
 
 permissions:
   contents: read

--- a/.github/workflows/watcher-rs.yml
+++ b/.github/workflows/watcher-rs.yml
@@ -3,6 +3,8 @@ name: Test (Rust)
 on:
   push:
     branches: [ release, next ]
+  pull_request:
+    branches: [ release, next ]
 
 env: 
   CARGO_TERM_COLOR: always

--- a/watcher-go/watcher_test.go
+++ b/watcher-go/watcher_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"testing/synctest"
 
 	"github.com/e-dant/watcher-go"
 )
@@ -27,29 +26,25 @@ func TestWatcher(t *testing.T) {
 	modifyEvent := make(chan *watcher.Event)
 	ready := make(chan struct{})
 
-	synctest.Test(t, func(t *testing.T) {
-		w := watcher.NewWatcher(dir, func(e *watcher.Event) {
-			if strings.HasPrefix(e.PathName, "s/self/live@") {
-				ready <- struct{}{}
+	w := watcher.NewWatcher(dir, func(e *watcher.Event) {
+		if strings.HasPrefix(e.PathName, "s/self/live@") {
+			ready <- struct{}{}
 
-				return
-			}
-
-			if e.EffectType == watcher.EffectTypeModify && strings.HasSuffix(e.PathName, "test.txt") {
-				modifyEvent <- e
-			}
-		})
-		t.Cleanup(w.Close)
-
-		// Wait for the watcher to be fully started
-		<-ready
-
-		if err := os.WriteFile(filepath.Join(dir, "test.txt"), []byte("test"), 0644); err != nil {
-			t.Fatalf("failed to write file: %v", err)
+			return
 		}
 
-		<-modifyEvent
-
-		synctest.Wait()
+		if e.EffectType == watcher.EffectTypeModify && strings.HasSuffix(e.PathName, "test.txt") {
+			modifyEvent <- e
+		}
 	})
+	t.Cleanup(w.Close)
+
+	// Wait for the watcher to be fully started
+	<-ready
+
+	if err := os.WriteFile(filepath.Join(dir, "test.txt"), []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	<-modifyEvent
 }

--- a/watcher-go/watcher_test.go
+++ b/watcher-go/watcher_test.go
@@ -24,22 +24,10 @@ func Example() {
 
 func TestWatcher(t *testing.T) {
 	dir := t.TempDir()
-	fileEvents := make(chan *watcher.Event)
+	modifyEvent := make(chan *watcher.Event)
 	ready := make(chan struct{})
 
 	synctest.Test(t, func(t *testing.T) {
-		go func() {
-			e := <-fileEvents
-			if e.EffectType != watcher.EffectTypeCreate {
-				t.Errorf("expected create event, got %v", e.EffectType)
-			}
-
-			e = <-fileEvents
-			if e.EffectType != watcher.EffectTypeModify {
-				t.Errorf("expected modify event, got %v", e.EffectType)
-			}
-		}()
-
 		w := watcher.NewWatcher(dir, func(e *watcher.Event) {
 			if strings.HasPrefix(e.PathName, "s/self/live@") {
 				ready <- struct{}{}
@@ -47,8 +35,8 @@ func TestWatcher(t *testing.T) {
 				return
 			}
 
-			if strings.HasSuffix(e.PathName, "test.txt") {
-				fileEvents <- e
+			if e.EffectType == watcher.EffectTypeModify && strings.HasSuffix(e.PathName, "test.txt") {
+				modifyEvent <- e
 			}
 		})
 		t.Cleanup(w.Close)
@@ -59,6 +47,8 @@ func TestWatcher(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(dir, "test.txt"), []byte("test"), 0644); err != nil {
 			t.Fatalf("failed to write file: %v", err)
 		}
+
+		<-modifyEvent
 
 		synctest.Wait()
 	})

--- a/watcher-go/watcher_test.go
+++ b/watcher-go/watcher_test.go
@@ -24,27 +24,37 @@ func Example() {
 
 func TestWatcher(t *testing.T) {
 	dir := t.TempDir()
-	events := make(chan *watcher.Event)
+	fileEvents := make(chan *watcher.Event)
+	ready := make(chan struct{})
 
 	synctest.Test(t, func(t *testing.T) {
 		go func() {
-			e := <-events
+			e := <-fileEvents
 			if e.EffectType != watcher.EffectTypeCreate {
 				t.Errorf("expected create event, got %v", e.EffectType)
 			}
 
-			e = <-events
+			e = <-fileEvents
 			if e.EffectType != watcher.EffectTypeModify {
 				t.Errorf("expected modify event, got %v", e.EffectType)
 			}
 		}()
 
 		w := watcher.NewWatcher(dir, func(e *watcher.Event) {
+			if strings.HasPrefix(e.PathName, "s/self/live@") {
+				ready <- struct{}{}
+
+				return
+			}
+
 			if strings.HasSuffix(e.PathName, "test.txt") {
-				events <- e
+				fileEvents <- e
 			}
 		})
 		t.Cleanup(w.Close)
+
+		// Wait for the watcher to be fully started
+		<-ready
 
 		if err := os.WriteFile(filepath.Join(dir, "test.txt"), []byte("test"), 0644); err != nil {
 			t.Fatalf("failed to write file: %v", err)


### PR DESCRIPTION
Unlike on macOS, on Linux the call to `wtr_watcher_open()` doesn't block until the watcher is ready.
We need to explicitly wait for the `s/self/live@...` event before creating the file.