### PR TITLE
ci: remove macOS 13, add macOS 15 and Windows 2025

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,8 +21,8 @@ jobs:
         target-platform:
           - this
         os:
-          - macos-13
           - macos-14
+          - macos-15
     steps:
       - uses: lukka/get-cmake@v3.29.3
       - uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,7 @@ jobs:
           - this
         os:
           - windows-2022
+          - windows-2025
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
macOS 13 is closing down: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/