### PR TITLE
fix: linking of the Go library on Windows

### DIFF
--- a/watcher-go/watcher.go
+++ b/watcher-go/watcher.go
@@ -2,7 +2,8 @@
 package watcher
 
 /*
-#cgo LDFLAGS: -lwatcher-c
+#cgo unix LDFLAGS: -lwatcher-c
+#cgo windows LDFLAGS: -llibwatcher-c
 #include <stdlib.h>
 #include <stdint.h>
 #include <wtr/watcher-c.h>


### PR DESCRIPTION
This prevents renaming the `.lib` file on windows.